### PR TITLE
cron jobsの実行時間を変更

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,11 @@
     "crons": [
         {
             "path": "/api/cron",
-            "schedule": "0 12 15 * *"
+            "schedule": "0 0 15 * *"
         },
         {
             "path": "/api/cron",
-            "schedule": "0 12 1 * *"
+            "schedule": "0 0 1 * *"
         }
     ]
 }


### PR DESCRIPTION
cron jobsの実行時間を変更した
日本時間で毎月1, 15日の朝9時に2週間分の集計を行い、投票がリセットされるようにした